### PR TITLE
 Initialize Adobe Enterprise CMS demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,3 +380,4 @@ MIT License - See [LICENSE](../../../LICENSE) for details.
 **Built with ❤️ using Cursor AI** - *Demonstrating the future of enterprise development*
 
 > *This demo showcases how Cursor transforms complex enterprise development from days of manual work to minutes of intelligent assistance. Perfect for organizations like Adobe who need sophisticated systems built quickly and correctly.*
+Small README tweak for PR.


### PR DESCRIPTION
Enterprise auth, assets, brands, content
Custom Org Chart tab (manager/reports)
Seed data (Elias → Samuel)
Admin UI custom navigation/pages
README, demo scripts, setup
Note: Prisma client is auto-generated on dev/build; no monorepo overrides

“Initial import of Adobe Enterprise CMS demo: enterprise auth, brand/content/assets, custom Org Chart tab, seed data (Elias → Samuel), Admin UI custom navigation, demo docs and scripts.”